### PR TITLE
fix: simplify gitignore entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ repos:
 |--------|------|---------|-------------|
 | `docsDir` | string | `"documentation"` | Output directory for copied docs |
 | `indicesDir` | string | `"documentation/indices"` | Output directory for index files |
-| `gitignore.addDocsDir` | boolean | `true` | Add docs directories to .gitignore |
-| `gitignore.addIndexFiles` | boolean | `false` | Add index files to .gitignore |
+| `gitignore.addDocsDir` | boolean | `true` | Add docs directory to .gitignore |
+| `gitignore.addIndexFiles` | boolean | `false` | Add indices directory to .gitignore |
 | `gitignore.sectionHeader` | string | `"Docpup generated docs"` | Header for .gitignore section |
 | `scan.includeMd` | boolean | `true` | Include .md files |
 | `scan.includeMdx` | boolean | `true` | Include .mdx files |

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -272,8 +272,8 @@ repos:
       expect(await fileExists(gitignorePath)).toBe(true);
 
       const content = await readFile(gitignorePath, "utf-8");
-      expect(content).toContain("documentation/axum/");
-      expect(content).toContain("documentation/indices/axum-index.md");
+      expect(content).toContain("documentation/");
+      expect(content).toContain("documentation/indices/");
     },
     TEST_TIMEOUT
   );


### PR DESCRIPTION
## Summary
Simplify `.gitignore` updates so docpup only ensures the configured docs and indices directories are ignored, instead of adding per‑repo entries.

## Changes
- Update gitignore logic to add just `docsDir/` and `indicesDir/` once
- Adjust integration test expectation to match new behavior
- Clarify README wording for gitignore options