### PR TITLE
chore: sync package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "hangzhou",
-  "version": "1.0.0",
+  "name": "docpup",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hangzhou",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "docpup",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "cosmiconfig": "^9.0.0",
@@ -17,12 +17,18 @@
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "docpup": "dist/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^25.1.0",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
## Summary
- align package-lock metadata with package.json (name, version, license, bin, engines)

## Testing
- not run (not requested)