### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docpup",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docpup",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpup",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI for indexing documentation from GitHub repositories.",
   "main": "dist/cli.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps package version to 0.1.2 for npm republish (0.1.1 was published without dist folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)